### PR TITLE
Allow scatter or gather-only steps with no Docker command to run

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dockerflow/transform/DockerDo.java
+++ b/src/main/java/com/google/cloud/genomics/dockerflow/transform/DockerDo.java
@@ -115,18 +115,24 @@ public class DockerDo
       pc = pc.apply(scatter(task));
     }
 
-    // Run the Docker task
-    pc = pc.apply(run(task));
+    // The task is not scatter or gather only
+    if (task.getDefn() != null &&
+        task.getDefn().getDocker() != null &&
+        task.getDefn().getDocker().getCmd() != null) {
 
-    // Add retries
-    if (task.getArgs() instanceof WorkflowArgs
-        && ((WorkflowArgs) task.getArgs()).getMaxTries() > 1) {
-      pc = pc.apply(retry(task));
+      // Run the Docker task
+      pc = pc.apply(run(task));
+
+      // Add retries
+      if (task.getArgs() instanceof WorkflowArgs
+          && ((WorkflowArgs) task.getArgs()).getMaxTries() > 1) {
+        pc = pc.apply(retry(task));
+      }
+
+      // Pass along the log paths and other outputs
+      pc = pc.apply(outputs(task));
     }
-
-    // Pass along the log paths and other outputs
-    pc = pc.apply(outputs(task));
-
+    
     // Gather
     if (task.getGatherBy() != null) {
       LOG.debug("gatherBy=" + task.getGatherBy());


### PR DESCRIPTION
Currently, scatter/gather have to be prepended or appended to Docker tasks. It's nice for readability to be able to have a scatter-only step in the workflow, or a gather-only step, without requiring a VM to launch. It can be easily done in memory. With this feature, the behavior is a little more like how Cromwell works for WDL workflows. 